### PR TITLE
complete xsk functions

### DIFF
--- a/bindings.c
+++ b/bindings.c
@@ -77,5 +77,5 @@ inline __u64 _xsk_umem__extract_offset(__u64 addr)
 
 inline __u64 _xsk_umem__add_offset_to_addr(__u64 addr)
 {
-    return _xsk_umem__add_offset_to_addr(addr);
+    return xsk_umem__add_offset_to_addr(addr);
 }

--- a/bindings.c
+++ b/bindings.c
@@ -9,13 +9,13 @@ inline __u64 *_xsk_ring_prod__fill_addr(struct xsk_ring_prod *fill, __u32 idx)
     return xsk_ring_prod__fill_addr(fill, idx);
 }
 
-inline const __u64 * _xsk_ring_cons__comp_addr(const struct xsk_ring_cons *comp, __u32 idx)
+inline const __u64 *_xsk_ring_cons__comp_addr(const struct xsk_ring_cons *comp, __u32 idx)
 {
-        return xsk_ring_cons__comp_addr(comp, idx);
+    return xsk_ring_cons__comp_addr(comp, idx);
 }
 
 inline size_t _xsk_ring_cons__peek(struct xsk_ring_cons *cons,
-                            size_t nb, __u32 *idx)
+                                   size_t nb, __u32 *idx)
 {
     return xsk_ring_cons__peek(cons, nb, idx);
 }
@@ -40,8 +40,9 @@ inline const struct xdp_desc *_xsk_ring_cons__rx_desc(const struct xsk_ring_cons
     return xsk_ring_cons__rx_desc(rx, idx);
 }
 
-inline extern struct xdp_desc *_xsk_ring_prod__tx_desc(struct xsk_ring_prod *tx, __u32 idx) {
-        return xsk_ring_prod__tx_desc(tx, idx);
+inline extern struct xdp_desc *_xsk_ring_prod__tx_desc(struct xsk_ring_prod *tx, __u32 idx)
+{
+    return xsk_ring_prod__tx_desc(tx, idx);
 }
 
 inline void *_xsk_umem__get_data(void *umem_area, __u64 addr)
@@ -49,6 +50,32 @@ inline void *_xsk_umem__get_data(void *umem_area, __u64 addr)
     return xsk_umem__get_data(umem_area, addr);
 }
 
-inline int _xsk_ring_prod__needs_wakeup(const struct xsk_ring_prod *r) {
-        return xsk_ring_prod__needs_wakeup(r);
+inline int _xsk_ring_prod__needs_wakeup(const struct xsk_ring_prod *r)
+{
+    return xsk_ring_prod__needs_wakeup(r);
+}
+
+inline int _xsk_prod_nb_free(struct xsk_ring_prod *r, __u32 nb)
+{
+    return xsk_prod_nb_free(r, nb);
+}
+
+inline int _xsk_cons_nb_avail(struct xsk_ring_cons *r, __u32 nb)
+{
+    return xsk_cons_nb_avail(r, nb);
+}
+
+inline __u64 _xsk_umem__extract_addr(__u64 addr)
+{
+    return xsk_umem__extract_addr(addr);
+}
+
+inline __u64 _xsk_umem__extract_offset(__u64 addr)
+{
+    return xsk_umem__extract_offset(addr);
+}
+
+inline __u64 _xsk_umem__add_offset_to_addr(__u64 addr)
+{
+    return _xsk_umem__add_offset_to_addr(addr);
 }

--- a/bindings.h
+++ b/bindings.h
@@ -23,3 +23,13 @@ extern struct xdp_desc *_xsk_ring_prod__tx_desc(struct xsk_ring_prod *tx, __u32 
 extern void *_xsk_umem__get_data(void *umem_area, __u64 addr);
 
 extern int _xsk_ring_prod__needs_wakeup(const struct xsk_ring_prod *r);
+
+extern int _xsk_prod_nb_free(struct xsk_ring_prod *r, __u32 nb);
+
+extern int _xsk_cons_nb_avail(struct xsk_ring_cons *r, __u32 nb);
+
+extern __u64 _xsk_umem__extract_addr(__u64 addr);
+
+extern __u64 _xsk_umem__extract_offset(__u64 addr);
+
+extern __u64 _xsk_umem__add_offset_to_addr(__u64 addr);

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -3315,6 +3315,21 @@ extern "C" {
 extern "C" {
     pub fn _xsk_ring_prod__needs_wakeup(r: *const xsk_ring_prod) -> ::std::os::raw::c_int;
 }
+extern "C" {
+    pub fn _xsk_prod_nb_free(r: *mut xsk_ring_prod, nb: __u32) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn _xsk_cons_nb_avail(r: *mut xsk_ring_cons, nb: __u32) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn _xsk_umem__extract_addr(addr: __u64) -> __u64;
+}
+extern "C" {
+    pub fn _xsk_umem__extract_offset(addr: __u64) -> __u64;
+}
+extern "C" {
+    pub fn _xsk_umem__add_offset_to_addr(addr: __u64) -> __u64;
+}
 pub type __builtin_va_list = [__va_list_tag; 1usize];
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
Not all inline xsk functions were covered in `bindings.h`

Added `xsk_prod_nb_free`, `xsk_cons_nb_avail`, `xsk_umem__extract_addr`, `xsk_umem__extract_offset`, `xsk_umem__add_offset_to_addr` and formatted bindings.c