### PR TITLE
update build.rs: expose libbpf include directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ authors = [
 license = "BSD-2-Clause"
 edition = "2018"
 build = "build.rs"
+links = "libbpf"
 
 [badges]
 travis-ci = { repository = "alexforster/libbpf-sys" }

--- a/build.rs
+++ b/build.rs
@@ -43,5 +43,6 @@ fn main() {
         println!("cargo:rustc-link-lib=elf");
         println!("cargo:rustc-link-lib=z");
         println!("cargo:rustc-link-lib=static=bpf");
+        println!("cargo:include={}/include", out_dir_str);
     }
 }


### PR DESCRIPTION
This allows user of this crate to retrieve the libbpf include dir via `DEP_LIBBPF_INCLUDE` environment variable.

Example of `build.rs`:

```rust
   let output = Command::new("clang")
        .arg("-g")
        .arg("-O2")
        .arg("-target")
        .arg("bpf")
        .arg("-c")
        .arg("./src/bpf/example.bpf.c")
        .arg("-o")
        .arg(&obj_path)
        .arg("-I")
        .arg(env::var("DEP_LIBBPF_INCLUDE").expect("Missing DEP_LIBBPF_INCLUDE environment variable"))
        .output()?;
```