### PR TITLE
Add `novendor` build flag to use system installed libbpf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,12 @@ maintenance = { status = "passively-maintained" }
 
 [build-dependencies]
 cc = "^1.0"
+pkg-config = "0.3"
 
 [lib]
 crate-type = ["lib", "staticlib"]
+
+[features]
+# When turned on, link against system-installed libbpf instead of building
+# and linking against vendored libbpf sources
+novendor = []

--- a/bindings.h
+++ b/bindings.h
@@ -1,8 +1,16 @@
+#ifdef __LIBBPF_SYS_NOVENDOR
+#include <linux/if_link.h>
+#include <bpf/bpf.h>
+#include <bpf/btf.h>
+#include <bpf/libbpf.h>
+#include <bpf/xsk.h>
+#else
 #include "libbpf/include/uapi/linux/if_link.h"
 #include "libbpf/src/bpf.h"
 #include "libbpf/src/btf.h"
 #include "libbpf/src/libbpf.h"
 #include "libbpf/src/xsk.h"
+#endif /* __LIBBPF_SYS_NOVENDOR */
 
 extern __u64 *_xsk_ring_prod__fill_addr(struct xsk_ring_prod *fill, __u32 idx);
 


### PR DESCRIPTION
This commit adds support to build libbpf-sys using the system installed
libbpf instead of building and linking against the vendored sources.

This is necessary to get libbpf-sys packaged into (most) distro's
package repositories. For example, Fedora has this requirement:
https://fedoraproject.org/wiki/Bundled_Libraries

This closes #10 .