### PR TITLE
Supply vendored libbpf headers as part of rust API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,26 @@
 #![allow(non_snake_case)]
 
 include!("bindings.rs");
+
+macro_rules! header {
+    ($file:literal) => {
+        ($file, include_str!(concat!("../libbpf/src/", $file)))
+    };
+}
+
+/// Vendored libbpf headers
+///
+/// Tuple format is: (header filename, header contents)
+#[cfg(not(feature = "novendor"))]
+pub const API_HEADERS: [(&'static str, &'static str); 10] = [
+    header!("bpf.h"),
+    header!("libbpf.h"),
+    header!("btf.h"),
+    header!("xsk.h"),
+    header!("bpf_helpers.h"),
+    header!("bpf_helper_defs.h"),
+    header!("bpf_tracing.h"),
+    header!("bpf_endian.h"),
+    header!("bpf_core_read.h"),
+    header!("libbpf_common.h"),
+];


### PR DESCRIPTION
When using libbpf-sys in vendored libbpf mode, it's best the end
application use matching headers when building the prog code against the
vendored C library. While API skew isn't a known issue yet, it's better
we get ahead of any issues.

This commit adds the public `API_HEADERS` constant that exposes all the
vendored headers. Downstream crates like libbpf-rs can in turn expose
the headers to applications.